### PR TITLE
Feature/full clean on save detached

### DIFF
--- a/django_fsm/db/fields/fsmfield.py
+++ b/django_fsm/db/fields/fsmfield.py
@@ -153,6 +153,7 @@ def transition(field=None, source='*', target=None, save=False, conditions=[]):
 
                 meta.to_next_state(instance)
                 if save:
+                    instance.full_clean()
                     instance.save()
 
                 post_transition.send(

--- a/django_fsm/db/fields/fsmfield.py
+++ b/django_fsm/db/fields/fsmfield.py
@@ -153,7 +153,17 @@ def transition(field=None, source='*', target=None, save=False, conditions=[]):
 
                 meta.to_next_state(instance)
                 if save:
+                    # Turn off write protection for Django's full_clean function.
+                    # This allows for CharField choice validation.
+                    protected = field.protected
+                    if protected:
+                        field.protected = False
+
                     instance.full_clean()
+
+                    if protected:
+                        field.protected = True
+
                     instance.save()
 
                 post_transition.send(


### PR DESCRIPTION
## Purpose

Currently, Django FSM field transitions do not check to see if the target state is a valid choice. This can lead to objects ending up in indeterminate states, breaking the point of a FSM to begin with. This PR adds field validations in the transition function before the `save()` function is called.
## Methodology

Django does not check the validity of the `CharField` in it's `save()` function, but rather in the `clean_fields()` function that is part of `full_clean()`. Due to the way write-protection works, simply adding a `full_clean` before the `save` function was not enough; `clean_fields()` uses `setattr()` to ensure the value of the field is clean, which is not allowed as long as the field is protected. To get around this, I temporarily disable the field's write protection, do the full clean, then re-enable it prior to saving. This protects the field from unintended outside side-effects while still allowing it to be validated as a proper state.
